### PR TITLE
BUG: ActiveSync device encryption policy enforcing fails on some devices

### DIFF
--- a/provider_src/com/android/email/SecurityPolicy.java
+++ b/provider_src/com/android/email/SecurityPolicy.java
@@ -375,8 +375,10 @@ public class SecurityPolicy {
                 }
             }
             if (policy.mRequireEncryption) {
-                int encryptionStatus = getDPM().getStorageEncryptionStatus();
-                if (encryptionStatus != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE) {
+                int encryptionStatus = dpm.getStorageEncryptionStatus();
+                if ((encryptionStatus != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE) &&
+                    (encryptionStatus != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVATING) &&
+                    (encryptionStatus != DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE_PER_USER)) {
                     reasons |= INACTIVE_NEED_ENCRYPTION;
                 }
             }


### PR DESCRIPTION
Via AOSP/Email I was unable to sign a Sony Xperia XA2 device into an Exchange mailbox, which enforces device encryption through ActiveSync policies - the enrollment process stuck in a loop popping up "Security update. me@xyz.org requires you to update your security settings."

To solve, patch getInactiveReasons(Policy policy) in SecurityPolicy.java to comply with the Android Dev Reference: According to https://developer.android.com/reference/android/app/admin/DevicePolicyManager?authuser=0&hl=vi#getStorageEncryptionStatus() no further action is required to make sure encryption is enabled if the result is ENCRYPTION_STATUS_ACTIVATING, ENCRYPTION_STATUS_ACTIVE or ENCRYPTION_STATUS_ACTIVE_PER_USER.

Reported to buganizer-system+192707@google.com on 29 Aug 2020.